### PR TITLE
Add data access layer with Dapper and configuration

### DIFF
--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -11,4 +11,9 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Core.csproj" />
+    <ProjectReference Include="..\Data\Data.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/API/Program.cs
+++ b/src/API/Program.cs
@@ -1,4 +1,12 @@
+using Data; // Added
+using Core.Interfaces; // Added
+using Core; // Added
+
 var builder = WebApplication.CreateBuilder(args);
+
+// Register custom services
+builder.Services.AddSingleton<Data.IDbConnectionFactory, Data.DbConnectionFactory>();
+builder.Services.AddScoped<Core.Interfaces.IExampleRepository, Data.ExampleRepository>();
 
 // Add services to the container.
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
@@ -34,6 +42,23 @@ app.MapGet("/weatherforecast", () =>
     return forecast;
 })
 .WithName("GetWeatherForecast")
+.WithOpenApi();
+
+app.MapGet("/examples", async (Core.Interfaces.IExampleRepository repo) =>
+{
+    try
+    {
+        var examples = await repo.GetAllAsync();
+        return Results.Ok(examples);
+    }
+    catch (System.Exception ex)
+    {
+        // Log the exception (implementation depends on logging setup)
+        // For now, return a generic error response
+        return Results.Problem($"An error occurred: {ex.Message}");
+    }
+})
+.WithName("GetAllExamples")
 .WithOpenApi();
 
 app.Run();

--- a/src/API/appsettings.Development.json
+++ b/src/API/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=MyDatabase;Trusted_Connection=True;"
   }
 }

--- a/src/API/appsettings.json
+++ b/src/API/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=MyDatabase;Trusted_Connection=True;"
+  }
 }

--- a/src/Core/Class1.cs
+++ b/src/Core/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace Core;
-
-public class Class1
-{
-
-}

--- a/src/Core/ExampleEntity.cs
+++ b/src/Core/ExampleEntity.cs
@@ -1,0 +1,8 @@
+namespace Core
+{
+    public class ExampleEntity
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/src/Core/IExampleRepository.cs
+++ b/src/Core/IExampleRepository.cs
@@ -1,0 +1,13 @@
+using Core; // For ExampleEntity
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Core.Interfaces // Or just namespace Core
+{
+    public interface IExampleRepository
+    {
+        Task<ExampleEntity> GetByIdAsync(int id);
+        Task<IEnumerable<ExampleEntity>> GetAllAsync();
+        // Add other methods like AddAsync, UpdateAsync, DeleteAsync as needed later
+    }
+}

--- a/src/Data/Class1.cs
+++ b/src/Data/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace Data;
-
-public class Class1
-{
-
-}

--- a/src/Data/Data.csproj
+++ b/src/Data/Data.csproj
@@ -8,6 +8,11 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.66" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Data/DbConnectionFactory.cs
+++ b/src/Data/DbConnectionFactory.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Configuration;
+using System.Data;
+using Microsoft.Data.SqlClient; // Or Npgsql if PostgreSQL was chosen
+
+namespace Data
+{
+    public class DbConnectionFactory : IDbConnectionFactory
+    {
+        private readonly IConfiguration _configuration;
+
+        public DbConnectionFactory(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public IDbConnection CreateConnection()
+        {
+            var connectionString = _configuration.GetConnectionString("DefaultConnection");
+            // Assuming SQL Server, replace with NpgsqlConnection for PostgreSQL
+            return new SqlConnection(connectionString);
+        }
+    }
+}

--- a/src/Data/ExampleRepository.cs
+++ b/src/Data/ExampleRepository.cs
@@ -1,0 +1,32 @@
+using Core; // For ExampleEntity
+using Core.Interfaces; // For IExampleRepository
+using Dapper;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Data
+{
+    public class ExampleRepository : IExampleRepository
+    {
+        private readonly IDbConnectionFactory _connectionFactory;
+
+        public ExampleRepository(IDbConnectionFactory connectionFactory)
+        {
+            _connectionFactory = connectionFactory;
+        }
+
+        public async Task<IEnumerable<ExampleEntity>> GetAllAsync()
+        {
+            using var connection = _connectionFactory.CreateConnection();
+            // Ensure the table name 'ExampleEntities' matches your actual database table
+            return await connection.QueryAsync<ExampleEntity>("SELECT * FROM ExampleEntities");
+        }
+
+        public async Task<ExampleEntity> GetByIdAsync(int id)
+        {
+            using var connection = _connectionFactory.CreateConnection();
+            // Ensure the table name 'ExampleEntities' and column 'Id' match your actual database
+            return await connection.QuerySingleOrDefaultAsync<ExampleEntity>("SELECT * FROM ExampleEntities WHERE Id = @Id", new { Id = id });
+        }
+    }
+}

--- a/src/Data/IDbConnectionFactory.cs
+++ b/src/Data/IDbConnectionFactory.cs
@@ -1,0 +1,9 @@
+using System.Data;
+
+namespace Data
+{
+    public interface IDbConnectionFactory
+    {
+        IDbConnection CreateConnection();
+    }
+}


### PR DESCRIPTION
This commit introduces the foundational elements for database interaction:

- Defines `ExampleEntity` in Core project.
- Adds `DefaultConnection` connection string to API configuration.
- Implements `DbConnectionFactory` for creating DB connections.
- Introduces `IExampleRepository` and `ExampleRepository` (using Dapper) for data access.
- Configures dependency injection for the new services.
- Sets up necessary project references.
- Adds a basic `/examples` API endpoint for testing data retrieval.

This provides a structured way to access data, with the connection string managed in configuration files as you requested.